### PR TITLE
Fix typos and improve debug detection

### DIFF
--- a/classes/cache-db.php
+++ b/classes/cache-db.php
@@ -259,7 +259,7 @@ class Transliteration_Cache_DB
 
     /*
      * Check is database table exists
-     * @verson    1.0.0
+     * @version   1.0.0
      */
     public static function table_exists($dry = false)
     {
@@ -295,7 +295,7 @@ class Transliteration_Cache_DB
 
     /*
      * Install missing tables
-     * @verson    1.0.0
+     * @version   1.0.0
      */
     public static function table_install(): void
     {
@@ -325,7 +325,7 @@ class Transliteration_Cache_DB
 
     /*
      * Instance
-     * @verson    1.0.0
+     * @version   1.0.0
      */
     public static function instance()
     {

--- a/classes/debug.php
+++ b/classes/debug.php
@@ -55,7 +55,7 @@ class Transliteration_Debug
     }
 
     /*
-     * Check if PHP is 64 bit vesion
+     * Check if PHP is 64 bit version
      *
      * @return boolean true or false
     */
@@ -79,36 +79,22 @@ class Transliteration_Debug
     }
 
     /*
-     * Check if any OS is 64 bit vesion
+     * Check if any OS is 64 bit version
      *
      * @return boolean true or false
     */
     public static function is_os64()
     {
-        // Let's ask system directly
-        if (function_exists('shell_exec')) {
-            if (self::is_win()) {
-                // Is Windows OS
-                $shell = shell_exec('wmic os get osarchitecture');
-                if (!($shell === '' || $shell === '0' || $shell === false || $shell === null) && strpos($shell ?? '', '64') !== false) {
-                    return true;
-                }
-            } else {
-                // Let's check some UNIX approach if is possible
-                $shell = shell_exec('uname -m');
-                if (!($shell === '' || $shell === '0' || $shell === false || $shell === null) && strpos($shell ?? '', '64') !== false) {
-                    return true;
-                }
+        // Check machine architecture using PHP
+        if (function_exists('php_uname')) {
+            $machine = php_uname('m');
+            if ($machine && strpos($machine, '64') !== false) {
+                return true;
             }
         }
 
-        // Check if PHP is 64 bit vesion (PHP 64bit only running on 64bit OS version)
-        $is_php64 = self::is_php64();
-        if ($is_php64) {
-            return true;
-        }
-        // bit-shifting can help also
-        return (bool) (1 << 32) - 1;
+        // Fallback to PHP architecture detection
+        return self::is_php64();
     }
 
     /**

--- a/classes/init.php
+++ b/classes/init.php
@@ -48,6 +48,12 @@ if (!class_exists('Transliteration_Init', false)) : final class Transliteration_
         }
     }
 
+    /**
+     * Set an admin detection cookie based on the requested URL.
+     *
+     * This allows other plugin components to know whether the current
+     * request is in the admin area without relying solely on is_admin().
+     */
     public function set_admin_cookie_based_on_url(): void
     {
         global $rstr_is_admin;

--- a/classes/maps/ar.php
+++ b/classes/maps/ar.php
@@ -34,6 +34,13 @@ class Transliteration_Map_ar
         '۸' => '8', '۹' => '9', '.' => '.',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/ba.php
+++ b/classes/maps/ba.php
@@ -59,6 +59,13 @@ class Transliteration_Map_ba
         'Я' => 'Ya', 'я' => 'ya',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/bel.php
+++ b/classes/maps/bel.php
@@ -39,6 +39,13 @@ class Transliteration_Map_bel
         'ч'  => 'č',	'ш' => 'š',	'ы' => 'y',	'ь' => "'",
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/bg_BG.php
+++ b/classes/maps/bg_BG.php
@@ -34,6 +34,13 @@ class Transliteration_Map_bg_BG
         'ь' => '',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/bs_BA.php
+++ b/classes/maps/bs_BA.php
@@ -44,6 +44,13 @@ class Transliteration_Map_bs_BA
         'ф' => 'f',	'х' => 'h',	'ц' => 'c',	'ч' => 'č',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/cnr.php
+++ b/classes/maps/cnr.php
@@ -46,6 +46,13 @@ class Transliteration_Map_cnr
         'ф' => 'f',	'х' => 'h',	'ц' => 'c',	'ч' => 'č',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/el.php
+++ b/classes/maps/el.php
@@ -38,6 +38,13 @@ class Transliteration_Map_el
         'μπ' => 'b',	'ντ' => 'd',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/hy.php
+++ b/classes/maps/hy.php
@@ -33,6 +33,13 @@ class Transliteration_Map_hy
         '№' => '#',	'—' => '-',	'«' => '',	'»' => '',	'…' => '',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/ka_GE.php
+++ b/classes/maps/ka_GE.php
@@ -30,6 +30,13 @@ class Transliteration_Map_ka_GE
         'ხ' => 'kh', 'Ხ' => 'Kh', 'ჯ' => 'j', 'Ჯ' => 'J', 'ჰ' => 'h', 'Ჰ' => 'H',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/kir.php
+++ b/classes/maps/kir.php
@@ -53,6 +53,13 @@ class Transliteration_Map_kir
         'Я' => 'Ya', 'я' => 'ya',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/kk.php
+++ b/classes/maps/kk.php
@@ -38,6 +38,13 @@ class Transliteration_Map_kk
         'Ъ' => '',		'ъ' => '',		'Ь' => '',		'ь' => '',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/mk_MK.php
+++ b/classes/maps/mk_MK.php
@@ -34,6 +34,13 @@ class Transliteration_Map_mk_MK
         'Х' => 'H',		'х' => 'h',		'Ъ' => 'Ǎ',		'ъ' => 'ǎ',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/mn.php
+++ b/classes/maps/mn.php
@@ -53,6 +53,13 @@ class Transliteration_Map_mn
         'Я' => 'Ya', 'я' => 'ya',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/ru_RU.php
+++ b/classes/maps/ru_RU.php
@@ -34,6 +34,13 @@ class Transliteration_Map_ru_RU
         'ъ' => '',  'ы' => 'y', 'ь' => '',  'э' => 'e',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (!is_string($content)) {

--- a/classes/maps/sr_RS.php
+++ b/classes/maps/sr_RS.php
@@ -43,6 +43,13 @@ class Transliteration_Map_sr_RS
         'ф' => 'f',	'х' => 'h',	'ц' => 'c',	'ч' => 'č',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/tg.php
+++ b/classes/maps/tg.php
@@ -51,6 +51,13 @@ class Transliteration_Map_tg
         'Ӯ' => 'U', 'ӯ' => 'u',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/maps/uk.php
+++ b/classes/maps/uk.php
@@ -41,6 +41,13 @@ class Transliteration_Map_uk
         'ь' => '', "'" => '',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (!is_string($content)) {

--- a/classes/maps/uz_UZ.php
+++ b/classes/maps/uz_UZ.php
@@ -53,6 +53,13 @@ class Transliteration_Map_uz_UZ
         'З' => 'Z', 'з' => 'z',
     ];
 
+    /**
+     * Transliterate text between Cyrillic and Latin.
+     *
+     * @param mixed $content String to transliterate.
+     * @param string $translation Conversion direction.
+     * @return mixed
+     */
     public static function transliterate($content, $translation = 'cyr_to_lat')
     {
         if (is_array($content) || is_object($content) || is_numeric($content) || is_bool($content)) {

--- a/classes/settings.php
+++ b/classes/settings.php
@@ -321,8 +321,10 @@ final class Transliteration_Settings extends Transliteration
 		<div class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables">
 				<?php
+// Hook triggered before settings sidebar
                     do_action('transliteration-settings-before-sidebar', 'general', $this);
         do_meta_boxes('transliteration-settings', 'side', null);
+// Hook triggered after settings sidebar
         do_action('transliteration-settings-after-sidebar', 'general', $this);
         ?>
 			</div>
@@ -394,8 +396,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		<div class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables">
 				<?php
+// Hook triggered before settings sidebar
                     do_action('transliteration-settings-before-sidebar', 'shortcodes', $this);
         do_meta_boxes('transliteration-settings', 'side', null);
+// Hook triggered after settings sidebar
         do_action('transliteration-settings-after-sidebar', 'shortcodes', $this);
         ?>
 			</div>
@@ -430,8 +434,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		<div class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables">
 				<?php
+// Hook triggered before settings sidebar
                     do_action('transliteration-settings-before-sidebar', 'functions', $this);
         do_meta_boxes('transliteration-settings', 'side', null);
+// Hook triggered after settings sidebar
         do_action('transliteration-settings-after-sidebar', 'functions', $this);
         ?>
 			</div>
@@ -466,8 +472,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		<div class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables">
 				<?php
+// Hook triggered before settings sidebar
                     do_action('transliteration-settings-before-sidebar', 'tags', $this);
         do_meta_boxes('transliteration-settings', 'side', null);
+// Hook triggered after settings sidebar
         do_action('transliteration-settings-after-sidebar', 'tags', $this);
         ?>
 			</div>
@@ -511,8 +519,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		<div class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables">
 				<?php
+// Hook triggered before settings sidebar
                     do_action('transliteration-settings-before-sidebar', 'transliteration', $this);
         do_meta_boxes('transliteration-tools', 'side', null);
+// Hook triggered after settings sidebar
         do_action('transliteration-settings-after-sidebar', 'transliteration', $this);
         ?>
 			</div>
@@ -540,8 +550,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		<div class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables">
 				<?php
+// Hook triggered before settings sidebar
                     do_action('transliteration-settings-before-sidebar', 'permalinks', $this);
         do_meta_boxes('transliteration-tools', 'side', null);
+// Hook triggered after settings sidebar
         do_action('transliteration-settings-after-sidebar', 'permalinks', $this);
         ?>
 			</div>
@@ -576,8 +588,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		<div class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables">
 				<?php
+// Hook triggered before settings sidebar
                     do_action('transliteration-settings-before-sidebar', 'debug', $this);
         do_meta_boxes('transliteration-settings', 'side', null);
+// Hook triggered after settings sidebar
         do_action('transliteration-settings-after-sidebar', 'debug', $this);
         ?>
 			</div>
@@ -604,8 +618,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		<div class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables">
 				<?php
+// Hook triggered before settings sidebar
                     do_action('transliteration-settings-before-sidebar', 'credits', $this);
         do_meta_boxes('transliteration-credits', 'side', null);
+// Hook triggered after settings sidebar
         do_action('transliteration-settings-after-sidebar', 'credits', $this);
         ?>
 			</div>

--- a/classes/settings/page-debug.php
+++ b/classes/settings/page-debug.php
@@ -5,7 +5,9 @@ $activations = get_option(RSTR_NAME . '-activation');
 $options     = get_rstr_option();
 ?><br>
 <table class="table table-sm table-striped w-100">
+<?php // Hook to extend debug table header ?>
 	<thead><?php do_action('rstr/settings/debug/table/thead'); ?></thead>
+<?php // Hook before first debug table row ?>
 	<tbody>
 		<?php do_action('rstr/settings/debug/table/tbody/start'); ?>
 		<tr>
@@ -110,7 +112,9 @@ $options     = get_rstr_option();
 		</tr>
 		<tr>
 			<td><strong><?php esc_html_e('Plugin directory path', 'serbian-transliteration'); ?></strong></td>
+<?php // Hook after last debug table row ?>
 			<td><?php echo RSTR_ROOT; ?></td>
+<?php // Hook to extend debug table footer ?>
 		</tr>
 		<?php do_action('rstr/settings/debug/table/tbody/end'); ?>
 	</tbody>

--- a/classes/utilities.php
+++ b/classes/utilities.php
@@ -11,7 +11,7 @@ class Transliteration_Utilities
     /*
      * Registered languages
      * @since     1.4.3
-     * @verson    1.0.0
+     * @version   1.0.0
      * @author    Ivijan-Stefan Stipic
      */
     public static function registered_languages()
@@ -472,7 +472,7 @@ class Transliteration_Utilities
     /*
      * Set cookie
      * @since     1.0.10
-     * @verson    1.0.0
+     * @version   1.0.0
     */
     public static function setcookie($val, $expire = null): bool
     {
@@ -500,7 +500,7 @@ class Transliteration_Utilities
     /*
      * Get current script
      * @since     1.0.10
-     * @verson    1.0.0
+     * @version   1.0.0
      */
     public static function get_current_script()
     {
@@ -523,7 +523,7 @@ class Transliteration_Utilities
 
     /*
      * Flush Cache
-     * @verson    1.0.1
+     * @version   1.0.1
      */
     protected static $cache_flush = false;
 
@@ -780,7 +780,7 @@ class Transliteration_Utilities
 
     /*
      * Check is in the Elementor editor mode
-     * @verson    1.0.0
+     * @version   1.0.0
      */
     public static function is_elementor_editor()
     {
@@ -805,7 +805,7 @@ class Transliteration_Utilities
 
     /*
      * Check is in the Elementor preview mode
-     * @verson    1.0.0
+     * @version   1.0.0
      */
     public static function is_elementor_preview()
     {
@@ -832,7 +832,7 @@ class Transliteration_Utilities
 
     /*
      * Check is in the Oxygen editor mode
-     * @verson    1.0.0
+     * @version   1.0.0
      */
     public static function is_oxygen_editor()
     {
@@ -894,7 +894,7 @@ class Transliteration_Utilities
     /*
      * PHP Wrapper for explode — Split a string by a string
      * @since     1.0.9
-     * @verson    1.0.0
+     * @version   1.0.0
      * @url       https://www.php.net/manual/en/function.explode.php
      */
     /**

--- a/classes/wp-cli.php
+++ b/classes/wp-cli.php
@@ -7,7 +7,7 @@ if (!defined('WPINC')) {
 /*
  * WP-CLI Helpers
  * @since     1.4.3
- * @verson    1.0.1
+ * @version   1.0.1
  * @author    Ivijan-Stefan Stipic
  */
 

--- a/constants.php
+++ b/constants.php
@@ -27,7 +27,7 @@ if (!function_exists('is_plugin_active_for_network') || !function_exists('is_plu
 /*
  * Main plugin constants
  * @since     1.0.0
- * @verson    1.0.0
+ * @version   1.0.0
 */
 
 // Plugin basename
@@ -80,9 +80,6 @@ if (!defined('RSTR_PREFIX')) {
 // Is multisite
 if (!defined('RSTR_MULTISITE')) {
     define('RSTR_MULTISITE', function_exists('is_plugin_active_for_network') ? is_plugin_active_for_network(RSTR_BASENAME) : false);
-}
-if (!defined('RSTR_MULTISITE')) {
-    define('RSTR_MULTISITE', false);
 }
 
 // Is Woocommerce exists

--- a/constants.php
+++ b/constants.php
@@ -1,6 +1,8 @@
 <?php if ( !defined('WPINC') ) die();
 
-// Find wp-admin file path
+/**
+ * Absolute path to the wp-admin directory.
+ */
 if (!defined('WP_ADMIN_DIR')) {
     // Default wp-admin directory
     $wp_admin_dir = ABSPATH . 'wp-admin';
@@ -15,7 +17,9 @@ if (!defined('WP_ADMIN_DIR')) {
     define('WP_ADMIN_DIR', rtrim($wp_admin_dir, '/\\'));
 }
 
-// Include Dependency
+/**
+ * Include plugin dependencies when plugin.php is accessible.
+ */
 $include_dependency = false;
 if (!function_exists('is_plugin_active_for_network') || !function_exists('is_plugin_active')) {
     if (file_exists(WP_ADMIN_DIR . '/includes/plugin.php')) {
@@ -30,36 +34,36 @@ if (!function_exists('is_plugin_active_for_network') || !function_exists('is_plu
  * @version   1.0.0
 */
 
-// Plugin basename
+/** Plugin basename used for activation checks. */
 if (!defined('RSTR_BASENAME')) {
     define('RSTR_BASENAME', plugin_basename(RSTR_FILE));
 }
-// Plugin root
+/** Absolute path to the plugin root directory. */
 if (!defined('RSTR_ROOT')) {
     define('RSTR_ROOT', rtrim(plugin_dir_path(RSTR_FILE) , '/'));
 }
-// Plugin URL root
+/** Base URL to the plugin directory. */
 if (!defined('RSTR_URL')) {
     define('RSTR_URL', rtrim(plugin_dir_url(RSTR_FILE) , '/'));
 }
-// Assets URL
+/** URL to plugin assets directory. */
 if (!defined('RSTR_ASSETS')) {
     define('RSTR_ASSETS', RSTR_URL . '/assets');
 }
-// Classes
+/** Directory containing plugin classes. */
 if (!defined('RSTR_CLASSES')) {
     define('RSTR_CLASSES', RSTR_ROOT . '/classes');
 }
-// Plugin name
+/** Option name used for storing plugin settings. */
 if (!defined('RSTR_NAME')) {
     define('RSTR_NAME', 'serbian-transliteration');
 }
-// Plugin table
+/** Database table slug for plugin tables. */
 if (!defined('RSTR_TABLE')) {
     define('RSTR_TABLE', 'serbian_transliteration');
 }
 
-// Current plugin version ( if change, clear also session cache )
+/** Plugin version derived from the header comment. */
 if (function_exists('get_file_data') && $plugin_data = get_file_data(RSTR_FILE, array(
     'Version' => 'Version'
 ) , false)) {
@@ -73,21 +77,21 @@ if (!$rstr_version && preg_match('/\*[\s\t]+?version:[\s\t]+?([0-9.]+)/i', file_
 if (!defined('RSTR_VERSION')) {
     define('RSTR_VERSION', $rstr_version);
 }
-// Plugin session prefix (controlled by version)
+/** Prefix used for transients and cache entries. */
 if (!defined('RSTR_PREFIX')) {
     define('RSTR_PREFIX', RSTR_TABLE . '_' . preg_replace("~[^0-9]~Ui", '', RSTR_VERSION) . '_');
 }
-// Is multisite
+/** True when plugin is network activated. */
 if (!defined('RSTR_MULTISITE')) {
     define('RSTR_MULTISITE', function_exists('is_plugin_active_for_network') ? is_plugin_active_for_network(RSTR_BASENAME) : false);
 }
 
-// Is Woocommerce exists
+/** Indicates whether WooCommerce is active. */
 if (!defined('RSTR_WOOCOMMERCE')) {
     define('RSTR_WOOCOMMERCE', (function_exists('is_plugin_active') ? is_plugin_active('woocommerce/woocommerce.php') : false));
 }
 
-// Normalize Latin String map
+/** Mapping of Unicode characters to ASCII equivalents. */
 if (!defined('RSTR_NORMALIZE_LATIN_STRING_MAP')) {
 	define('RSTR_NORMALIZE_LATIN_STRING_MAP', array(
 		'À'=>'A', 'Á'=>'A', 'Â'=>'A', 'Ã'=>'A', 'Ä'=>'A', 'Å'=>'A', 'Ă'=>'A', 'Ā'=>'A', 'Ą'=>'A', 'Æ'=>'A', 'Ǽ'=>'A',

--- a/serbian-transliteration.php
+++ b/serbian-transliteration.php
@@ -80,7 +80,7 @@ if (! defined('RSTR_DATABASE_VERSION')) {
 /**
  * Main plugin constants
  * @since     1.1.0
- * @verson    1.0.0
+ * @version   1.0.0
  */
 // Main plugin file
 if (! defined('RSTR_FILE')) {
@@ -111,7 +111,7 @@ $rstr_is_admin = ($_COOKIE['rstr_test_' . COOKIEHASH] ?? 'false' === 'true');
 /*
  * Get plugin options
  * @since     1.1.3
- * @verson    1.0.0
+ * @version   1.0.0
  */
 if (!function_exists('get_rstr_option')) {
     function get_rstr_option($name = false, $default = null)


### PR DESCRIPTION
## Summary
- fix documentation typos
- remove redundant constant definition
- replace shell commands with php_uname in debug helper

## Testing
- `php -l serbian-transliteration.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d3f11bbc8322bcb07b97cb980eda