### PR TITLE
Decode HTML entities before transliteration

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -371,6 +371,9 @@ final class Transliteration_Controller extends Transliteration
             return $content;
         }
 
+        // Decode entities to ensure characters are transliterated correctly
+        $content = Transliteration_Utilities::decode($content);
+
         /*// Don't transliterate if we already have transliteration
         if (!Transliteration_Utilities::is_cyr($content)) {
             return $content;


### PR DESCRIPTION
## Summary
- ensure HTML entities are decoded before calling `lat_to_cyr`

## Testing
- `php test.php`

------
https://chatgpt.com/codex/tasks/task_e_6877a624bdf8832295799e7c412ba694