### PR TITLE
Optimize query to use offset instead of paged

### DIFF
--- a/serbian-transliteration.php
+++ b/serbian-transliteration.php
@@ -208,7 +208,7 @@ function rstr_render_network_settings() {
     do {
         $batch = get_sites(array(
             'number' => $number,
-            'paged'  => $paged,
+            'offset' => ($paged - 1) * $number,
             'fields' => 'all',
         ));
         if (empty($batch)) {


### PR DESCRIPTION
## Description

I'm working on a large multisite and getting this error: 
```
[Wed Mar 04 23:53:46.919914 2026] [php:error] [pid 63:tid 63] [client 10.0.169.34:59048] PHP Fatal error:  Maximum execution time of 60 seconds exceeded in /var/www/html/wp-content/plugins/serbian-transliteration/serbian-transliteration.php on line 217, referer: /wp-admin/network/plugins.php
```

Updating to use an offset instead of pages fixes.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Before submitting this pull request, please make sure:

- [x] You have followed the WordPress coding standards.
- [x] Your code has been tested and all tests pass.
- [x] You have updated the documentation (if necessary).
- [x] You have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] The code changes are only for the intended purpose and do not include unrelated updates or changes.

## Testing Instructions

If it didn't work, the initialization would fail! :) 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the GPL-2.0+ license.
